### PR TITLE
Changed output type for components of the decomposition techniques

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: python
 
+os:
+  - linux
+  - osx
+
 python:
   - "3.5"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 os:
   - linux
-  - osx
 
 python:
   - "3.5"

--- a/skhyper/decomposition/_fastica.py
+++ b/skhyper/decomposition/_fastica.py
@@ -54,9 +54,15 @@ class FastICA:
 
     Attributes
     ----------
-    image_components_ : array, shape (x, y, (z), n_components)
+    image_components_ : list
+        Returns a list of image arrays for each component. The size is:
+            - n_components: If the number of components were specified
+            - n_features: If the number of components were not specified
 
-    spec_components_ : array, shape(n_features, n_components)
+    spec_components_ : list
+        Returns a list of spectral arrays for each component. The size is:
+            - n_components: If the number of components were specified
+            - n_features: If the number of components were not specified
 
     mdl : object, FastICA() instance
         An instance of the FastICA model from scikit-learn used when
@@ -155,10 +161,26 @@ class FastICA:
         self.n_iter_ = mdl.n_iter_
 
         if not self.n_components:
-            self.image_components_ = np.reshape(w_matrix, self._X.shape)
+            self.image_components_ = [0] * self._X.shape[-1]
+            self.spec_components_ = [0] * self._X.shape[-1]
+
+            w_matrix_ord = np.reshape(w_matrix, self._X.shape)
+            h_matrix_ord = h_matrix.T
+
+            for comp in range(self._X.shape[-1]):
+                self.image_components_[comp] = np.squeeze(w_matrix_ord[..., comp])
+                self.spec_components_[comp] = h_matrix_ord[..., comp]
+
         else:
-            self.image_components_ = np.reshape(w_matrix, self._X.shape[:-1] + (self.n_components,))
-        self.spec_components_ = h_matrix.T
+            self.image_components_ = [0] * self.n_components
+            self.spec_components_ = [0] * self.n_components
+
+            w_matrix_ord = np.reshape(w_matrix, self._X.shape[:-1] + (self.n_components,))
+            h_matrix_ord = h_matrix.T
+
+            for comp in range(self.n_components):
+                self.image_components_[comp] = np.squeeze(w_matrix_ord[..., comp])
+                self.spec_components_[comp] = h_matrix_ord[..., comp]
 
         return self
 

--- a/skhyper/decomposition/_nmf.py
+++ b/skhyper/decomposition/_nmf.py
@@ -81,9 +81,15 @@ class NMF:
 
     Attributes
     ----------
-    image_components_ : array, shape (x, y, (z), n_components)
+    image_components_ : list
+        Returns a list of image arrays for each component. The size is:
+            - n_components: If the number of components were specified
+            - n_features: If the number of components were not specified
 
-    spec_components_ : array, shape(n_features, n_components)
+    spec_components_ : list
+        Returns a list of spectral arrays for each component. The size is:
+            - n_components: If the number of components were specified
+            - n_features: If the number of components were not specified
 
     mdl : object, NMF() instance
         An instance of the NMF model from scikit-learn used when
@@ -185,10 +191,26 @@ class NMF:
         self.n_iter_ = mdl.n_iter_
 
         if not self.n_components:
-            self.image_components_ = np.reshape(w_matrix, self._X.shape)
+            self.image_components_ = [0] * self._X.shape[-1]
+            self.spec_components_ = [0] * self._X.shape[-1]
+
+            w_matrix_ord = np.reshape(w_matrix, self._X.shape)
+            h_matrix_ord = h_matrix.T
+
+            for comp in range(self._X.shape[-1]):
+                self.image_components_[comp] = np.squeeze(w_matrix_ord[..., comp])
+                self.spec_components_[comp] = h_matrix_ord[..., comp]
+
         else:
-            self.image_components_ = np.reshape(w_matrix, self._X.shape[:-1] + (self.n_components,))
-        self.spec_components_ = h_matrix.T
+            self.image_components_ = [0] * self.n_components
+            self.spec_components_ = [0] * self.n_components
+
+            w_matrix_ord = np.reshape(w_matrix, self._X.shape[:-1] + (self.n_components,))
+            h_matrix_ord = h_matrix.T
+
+            for comp in range(self.n_components):
+                self.image_components_[comp] = np.squeeze(w_matrix_ord[..., comp])
+                self.spec_components_[comp] = h_matrix_ord[..., comp]
 
         return self
 

--- a/skhyper/decomposition/_pca.py
+++ b/skhyper/decomposition/_pca.py
@@ -67,9 +67,15 @@ class PCA:
 
     Attributes
     ----------
-    image_components_ : array, shape (x, y, (z), n_components)
+    image_components_ : list
+        Returns a list of image arrays for each component. The size is:
+            - n_components: If the number of components were specified
+            - n_features: If the number of components were not specified
 
-    spec_components_ : array, shape(n_features, n_components)
+    spec_components_ : list
+        Returns a list of spectral arrays for each component. The size is:
+            - n_components: If the number of components were specified
+            - n_features: If the number of components were not specified
 
     mdl : object, PCA() instance
         An instance of the PCA model from scikit-learn used when instantiating PCA() from scikit-hyper
@@ -216,10 +222,26 @@ class PCA:
         self.noise_variance_ = mdl.noise_variance_
 
         if not self.n_components:
-            self.image_components_ = np.reshape(w_matrix, self._X.shape)
+            self.image_components_ = [0] * self._X.shape[-1]
+            self.spec_components_ = [0] * self._X.shape[-1]
+
+            w_matrix_ord = np.reshape(w_matrix, self._X.shape)
+            h_matrix_ord = h_matrix.T
+
+            for comp in range(self._X.shape[-1]):
+                self.image_components_[comp] = np.squeeze(w_matrix_ord[..., comp])
+                self.spec_components_[comp] = h_matrix_ord[..., comp]
+
         else:
-            self.image_components_ = np.reshape(w_matrix, self._X.shape[:-1] + (self.n_components,))
-        self.spec_components_ = h_matrix.T
+            self.image_components_ = [0] * self.n_components
+            self.spec_components_ = [0] * self.n_components
+
+            w_matrix_ord = np.reshape(w_matrix, self._X.shape[:-1] + (self.n_components,))
+            h_matrix_ord = h_matrix.T
+
+            for comp in range(self.n_components):
+                self.image_components_[comp] = np.squeeze(w_matrix_ord[..., comp])
+                self.spec_components_[comp] = h_matrix_ord[..., comp]
 
         return self
 

--- a/tests/test_decomposition.py
+++ b/tests/test_decomposition.py
@@ -34,6 +34,9 @@ class TestDecomposition:
         assert mdl_3d.mean_ is not None
         assert mdl_3d.noise_variance_ is not None
 
+        assert len(mdl_3d.image_components_) == 32
+        assert len(mdl_3d.spec_components_) == 32
+
         Xd_3d = mdl_3d.inverse_transform(n_components=10, perform_anscombe=True)
         assert Xd_3d is not None
 
@@ -49,6 +52,9 @@ class TestDecomposition:
         assert mdl_4d.singular_values_ is not None
         assert mdl_4d.mean_ is not None
         assert mdl_4d.noise_variance_ is not None
+
+        assert len(mdl_4d.image_components_) == 32
+        assert len(mdl_4d.spec_components_) == 32
 
         Xd_4d = mdl_4d.inverse_transform(n_components=10, perform_anscombe=True)
         assert Xd_4d is not None
@@ -70,16 +76,26 @@ class TestDecomposition:
 
         # 3-dimensional data
         mdl_3d.fit_transform(self.X_3d)
+        assert mdl_3d.image_components_ is not None
+        assert mdl_3d.spec_components_ is not None
         assert mdl_3d.reconstruction_err_ is not None
         assert mdl_3d.n_iter_ is not None
+
+        assert len(mdl_3d.image_components_) == 3
+        assert len(mdl_3d.spec_components_) == 3
 
         Xd_3d = mdl_3d.inverse_transform(n_components=1)
         assert Xd_3d is not None
 
         # 4-dimensional data
         mdl_4d.fit_transform(self.X_4d)
+        assert mdl_4d.image_components_ is not None
+        assert mdl_4d.spec_components_ is not None
         assert mdl_4d.reconstruction_err_ is not None
         assert mdl_4d.n_iter_ is not None
+
+        assert len(mdl_4d.image_components_) == 3
+        assert len(mdl_4d.spec_components_) == 3
 
         Xd_4d = mdl_4d.inverse_transform(n_components=1)
         assert Xd_4d is not None
@@ -90,16 +106,26 @@ class TestDecomposition:
 
         # 3-dimensional data
         mdl_3d.fit_transform(self.X_3d)
+        assert mdl_3d.image_components_ is not None
+        assert mdl_3d.spec_components_ is not None
         assert mdl_3d.mixing_ is not None
         assert mdl_3d.n_iter_ is not None
+
+        assert len(mdl_3d.image_components_) == 3
+        assert len(mdl_3d.spec_components_) == 3
 
         Xd_3d = mdl_3d.inverse_transform(n_components=1)
         assert Xd_3d is not None
 
         # 4-dimensional data
         mdl_4d.fit_transform(self.X_4d)
+        assert mdl_4d.image_components_ is not None
+        assert mdl_4d.spec_components_ is not None
         assert mdl_4d.mixing_ is not None
         assert mdl_4d.n_iter_ is not None
+
+        assert len(mdl_4d.image_components_) == 3
+        assert len(mdl_4d.spec_components_) == 3
 
         Xd_4d = mdl_4d.inverse_transform(n_components=1)
         assert Xd_4d is not None


### PR DESCRIPTION
The following attributes of the decomposition classes (PCA, FastICA and NMF) have been changed from an array to a list of arrays, with the number of elements in the list reflecting the number of components chosen:

+ image_components
+ spec_components